### PR TITLE
Fix scrapy settings priority over global settings

### DIFF
--- a/arachne/scrapy_utils.py
+++ b/arachne/scrapy_utils.py
@@ -52,7 +52,9 @@ def get_spider_settings(flask_app_config, spider_scrapy_settings):
        Allow settings for individual spiders and global settings
     """
     all_settings = flask_app_config
-    default_scrapy_settings = flask_app_config['SCRAPY_SETTINGS']
+
+    # Merge the SCRAPY_SETTINGS to the rest of settings available in default_settings.py
+    all_settings.update(flask_app_config['SCRAPY_SETTINGS'])
 
     if 'EXTENSIONS' not in all_settings:
         all_settings['EXTENSIONS'] = {}
@@ -64,12 +66,9 @@ def get_spider_settings(flask_app_config, spider_scrapy_settings):
         all_settings['EXTENSIONS']['arachne.extensions.ExportCSV'] = 200
 
     # spider scrapy settings has priority over global scrapy settings
+    # This updates the all_settings dict with values from spider_scrapy_settings, if provided.
     if spider_scrapy_settings:
-        for setting, _ in spider_scrapy_settings.items():
-            if setting in default_scrapy_settings:
-                all_settings[setting].update(spider_scrapy_settings[setting])
-            else:
-                all_settings[setting] = spider_scrapy_settings[setting]
+        all_settings.update(spider_scrapy_settings)
 
     settings = Settings(all_settings)
     return settings

--- a/arachne/scrapy_utils.py
+++ b/arachne/scrapy_utils.py
@@ -51,7 +51,8 @@ def get_spider_settings(flask_app_config, spider_scrapy_settings):
     .. version 0.3.0:
        Allow settings for individual spiders and global settings
     """
-    all_settings = flask_app_config['SCRAPY_SETTINGS']
+    all_settings = flask_app_config
+    default_scrapy_settings = flask_app_config['SCRAPY_SETTINGS']
 
     if 'EXTENSIONS' not in all_settings:
         all_settings['EXTENSIONS'] = {}
@@ -65,7 +66,7 @@ def get_spider_settings(flask_app_config, spider_scrapy_settings):
     # spider scrapy settings has priority over global scrapy settings
     if spider_scrapy_settings:
         for setting, _ in spider_scrapy_settings.items():
-            if setting in all_settings:
+            if setting in default_scrapy_settings:
                 all_settings[setting].update(spider_scrapy_settings[setting])
             else:
                 all_settings[setting] = spider_scrapy_settings[setting]

--- a/arachne/scrapy_utils.py
+++ b/arachne/scrapy_utils.py
@@ -63,9 +63,12 @@ def get_spider_settings(flask_app_config, spider_scrapy_settings):
         all_settings['EXTENSIONS']['arachne.extensions.ExportCSV'] = 200
 
     # spider scrapy settings has priority over global scrapy settings
-    for setting, _ in all_settings.items():
-        if spider_scrapy_settings and setting in spider_scrapy_settings:
-            all_settings[setting].update(spider_scrapy_settings[setting])
+    if spider_scrapy_settings:
+        for setting, _ in spider_scrapy_settings.items():
+            if setting in all_settings:
+                all_settings[setting].update(spider_scrapy_settings[setting])
+            else:
+                all_settings[setting] = spider_scrapy_settings[setting]
 
     settings = Settings(all_settings)
     return settings


### PR DESCRIPTION
#### What does this PR do?
- Fix the settings defined in **default_settings.py** not being applied. Currently, only settings specified in **SCRAPY_SETTINGS,** which itself is an empty dict are evaluated and applied.
- Fix settings defined in individual spiders in **spider_scrappy_settings** not overriding the default settings. 

#### How should this be manually tested?
No separate/new tests required as those available cover the changes.

#### Background context 

I had wanted to use this module for some scrapping work, but item_pipelines were never applied. This should fix that.

This should fix issue: https://github.com/kirankoduru/arachne/issues/17